### PR TITLE
Removed the setView() method

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,8 +73,6 @@ int main()
             }
         }
 
-        screen.setView(view);
-
         // Finish Draw
 
         screen.display();


### PR DESCRIPTION
This PR Closes DucktapeEngine#2

The method has been removed to prevent the "Stretching" effect of the sprite.

This should be handled independently in a separate method in order to be able to correctly set the Viewport and calculate the new size to preserve the aspect ratio.

However, for simplicity, this "line of code removal" will hopefully solve the issue and nothing else in the GUI will be affected!