### PR TITLE
Fix the engine loop so Tick is not called in Editor mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,16 @@ Choose the build type:
 2) Release
 Enter your option (1,2):
 ```
+Now the Engine and the Editor should compile.
 
-Then run 
+Note that before you run the Editor, you need to copy the Dll binaries of glfw, glad, assimp, and imgui to the same directory as the Editor exe (./Build/Editor).
+These files are usually situated in:
+- ./Build/Extern/glfw/src
+- ./Build/Extern/glad
+- ./Build/Extern/assimp/bin
+- ./Build/Extern/imgui
+
+Now run 
 ```
 ./Editor/Editor.exe
 ```

--- a/Editor/Main.cpp
+++ b/Editor/Main.cpp
@@ -60,11 +60,12 @@ int main()
         model.Assign<Transform>();
 
         std::vector<Mesh> meshes = LoadModel("../Resources/Models/backpack/backpack.obj").meshes;
-        // std::vector<Mesh> meshes = LoadModel("../Resources/Models/cube.obj").meshes;
         for (Mesh mesh : meshes)
         {
             mainScene.CreateEntity().Assign<MeshRenderer>().mesh = mesh;
         }
+
+        e.loopManager.sceneTick = false;
 
         e.Init(mainScene);
 

--- a/Engine/Components/DirectionalLight.cpp
+++ b/Engine/Components/DirectionalLight.cpp
@@ -67,6 +67,11 @@ namespace DT
         shader->SetBool(propertyString + "enabled", true);
     }
 
+    void DirectionalLight::SceneView(bool selected)
+    {
+        Tick();
+    }
+
     void DirectionalLight::System(Scene *scene)
     {
         scene->Call<DirectionalLight>();

--- a/Engine/Components/DirectionalLight.h
+++ b/Engine/Components/DirectionalLight.h
@@ -43,6 +43,7 @@ namespace DT
         void Init();
         void Tick();
         void Inspector();
+        void SceneView(bool selected);
         void Destroy();
         static void System(Scene *scene);
     };

--- a/Engine/Components/MeshRenderer.cpp
+++ b/Engine/Components/MeshRenderer.cpp
@@ -53,6 +53,11 @@ namespace DT
         }
     }
 
+    void MeshRenderer::SceneView(bool selected)
+    {
+        Tick();
+    }
+
     void MeshRenderer::System(Scene *scene)
     {
         scene->Call<MeshRenderer>();

--- a/Engine/Components/MeshRenderer.h
+++ b/Engine/Components/MeshRenderer.h
@@ -41,6 +41,7 @@ namespace DT
         void Init();
         void Tick();
         void Inspector();
+        void SceneView(bool selected);
         static void System(Scene *scene);
     };
 }

--- a/Engine/Components/PointLight.cpp
+++ b/Engine/Components/PointLight.cpp
@@ -67,6 +67,11 @@ namespace DT
         }
     }
 
+    void PointLight::SceneView(bool selected)
+    {
+        Tick();
+    }
+
     void PointLight::Destroy()
     {
         engine->renderer.UnoccupyPointLightSpot(lightSpot);

--- a/Engine/Components/PointLight.h
+++ b/Engine/Components/PointLight.h
@@ -43,6 +43,7 @@ namespace DT
         void Init();
         void Tick();
         void Inspector();
+        void SceneView(bool selected);
         void Destroy();
         static void System(Scene *scene);
     };


### PR DESCRIPTION
## Proposed Changes

  - Update Contributing.md to mention about the dynamic library binaries that must be placed in the Editor directory.
  - Fix the engine loop so Tick is not called in Editor mode.