### PR TITLE
Small correction to Linux build

### DIFF
--- a/CMake/FindDucktape.cmake
+++ b/CMake/FindDucktape.cmake
@@ -56,16 +56,7 @@ set (Ducktape_LIBRARY_DIR
     ${Ducktape_ROOT_DIR}/Build/Extern/imgui;
 )
 
-if (UNIX)
-	set (Ducktape_LIBRARY
-	    stdc++
-	    m
-	    pthread
-	)
-endif()
-
 set (Ducktape_LIBRARY
-    ${Ducktape_LIBRARY}
     Ducktape
     glfw
     ${OPENGL_gl_LIBRARY}
@@ -76,12 +67,8 @@ set (Ducktape_LIBRARY
     imgui
 )
 if (UNIX)
-	set (Ducktape_LIBRARY ${Ducktape_LIBRARY}
-	    dl
-	    X11
-	)
+    set (Ducktape_LIBRARY
+	${Ducktape_LIBRARY}
+	dl
+    )
 endif()
-set (Ducktape_LIBRARY
-    ${Ducktape_LIBRARY}
-    imgui
-)


### PR DESCRIPTION
Hi again. I after pushing to my previous PR #132 I realized that these things weren't necessary now that it worked correctly. But since you already merged it I'll just make another one. You can label this pr `invalid` for Hacktoberfest if you want.

Below is the comment I was gonna write on the original PR, but I realized you already merged:

I managed to get it to build. It helped to take a little break :sweat_smile: . I found the reason it was failing with the External (see commit "Fix building on Linux"). Your code snippet for the dll export worked (at least for getting around the compiler error). 

I also needed to install a bunch of system dependencies as well. They were detected when running `cmake` and not as linker errors. I just forgot to include it earlier.

Now I can start the editor. Though there are still a handful of syntax errors in shaders and some DLL error that shows up when I run it. But I can click around on some buttons at least.