### PR TITLE
Add dependency install scripts for Arch and Debian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 build
 Build
+imgui.ini

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,14 @@ Then, clone the repository using:
 git clone https://github.com/<username>/Ducktape.git
 ```
 
-### Install dependencies (Linux)
+### Install dependencies
+#### Debian
 ```sh
-sudo apt install libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev
+sudo apt install libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev libglfw3-dev libassimp-dev
+```
+#### Arch
+```sh
+sudo pacman -S libx11 libxrandr libxinerama libxcursor libxi mesa assimp glfw-x11
 ```
 
 ### Compile Ducktape

--- a/Engine/CMakeLists.txt
+++ b/Engine/CMakeLists.txt
@@ -1,24 +1,24 @@
-﻿# Ducktape | An open source C++ 2D & 3D game Engine that focuses on being fast, and powerful.
+# Ducktape | An open source C++ 2D & 3D game Engine that focuses on being fast, and powerful.
 # Copyright (C) 2022 Aryan Baburajan
-# 
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-# 
+#
 # In case of any further questions feel free to contact me at
 # the following email address:
 # aryanbaburajan2007@gmail.com
 
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required(VERSION 3.8)
 
 set(CMAKE_CXX_STANDARD 20)
 
@@ -27,12 +27,11 @@ file(GLOB_RECURSE source_list "${PROJECT_SOURCE_DIR}/Engine/**/*.cpp" "${PROJECT
 
 set(CMAKE_CXX_FLAGS "-fPIC")
 
-add_library (Ducktape
+add_library(Ducktape
     ${source_list}
 )
 
 set_target_properties(Ducktape PROPERTIES
-    CXX_STANDARD 20
     CXX_EXTENSIONS OFF
 )
 
@@ -40,12 +39,13 @@ target_include_directories(Ducktape PUBLIC "${PROJECT_SOURCE_DIR}/Engine/")
 target_compile_features(Ducktape PRIVATE cxx_std_17)
 
 # Dependencies
-find_package (OpenGL REQUIRED)
-if (OPENGL_FOUND)
-    message ("-- OpenGL found.")
-else (OPENGL_FOUND)
-    message ("-- OpenGL not found.")
-endif ()
+find_package(OpenGL REQUIRED)
+
+if(OPENGL_FOUND)
+    message("-- OpenGL found.")
+else(OPENGL_FOUND)
+    message("-- OpenGL not found.")
+endif()
 
 target_include_directories(Ducktape PUBLIC
     ${PROJECT_SOURCE_DIR}/Engine;

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 
-DEPS="libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev"
-
 echo Setting up Ducktape for compiling...
-echo -e "Installing dependencies... \n$DEPS"
-sudo apt install $DEPS
 
 echo Choose your generator:
 echo 1\) Borland Makefiles

--- a/install-deps-arch.sh
+++ b/install-deps-arch.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+DEPS="libx11 libxrandr libxinerama libxcursor libxi mesa libglu1-mesa-dev libassimp-dev"
+
+
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root to install the required dependencies"
+  exit
+fi
+
+read -p "Do you want to download dependencies for Wayland or X11?[X/wayland]" DSP
+if [ "$DSP" -eq "wayland" ] 
+  then DEPS="$DEPS glfw-wayland"
+else
+  DEPS="$DEPS glfw-x11"
+fi
+
+DEPS="libx11 libxrandr libxinerama libxcursor libxi mesa assimp"
+echo -e "Installing dependencies... \n$DEPS"
+pacman -S $DEPS

--- a/install-deps-debian.sh
+++ b/install-deps-debian.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ "$EUID" -ne 0 ]
+  then echo "Please run as root to install the required dependencies"
+  exit
+fi
+
+DEPS="libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev libglfw3-dev libassimp-dev"
+echo -e "Installing dependencies... \n$DEPS"
+apt install $DEPS


### PR DESCRIPTION
Added dependency installation scripts for Arch and Debian, also added instructions in CONTRIBUTING.md, also fixes a minor error which made ducktape require C++20