### PR TITLE
Switch to using system libraries on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,10 @@ set(OpenGL_GL_PREFERENCE LEGACY)
 if(WIN32)
     add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/assimp")
     add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/glfw")
-    add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/glad")
-    add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/imgui")
 endif(WIN32)
+
+add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/glad")
+add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/imgui")
 
 set(BUILD_SHARED_LIBS OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(BUILD_ASSIMP_TOOLS OFF)
 set(ASSIMP_BUILD_TESTS OFF)
 set(ASSIMP_WARNINGS_AS_ERRORS OFF)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/Extern/assimp/cmake-modules/;${CMAKE_MODULE_PATH}")
+set(OpenGL_GL_PREFERENCE LEGACY)
 
 if(WIN32)
     add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/assimp")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-cmake_minimum_required (VERSION 3.8)
+cmake_minimum_required(VERSION 3.8)
 
-project ("Ducktape")
+project("Ducktape")
 
 set(ASSIMP_BUILD_ZLIB ON)
 set(BUILD_SHARED_LIBS ON)
@@ -8,10 +8,14 @@ set(BUILD_ASSIMP_TOOLS OFF)
 set(ASSIMP_BUILD_TESTS OFF)
 set(ASSIMP_WARNINGS_AS_ERRORS OFF)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/Extern/assimp/cmake-modules/;${CMAKE_MODULE_PATH}")
-add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/assimp")
-add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/glfw")
-add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/glad")
-add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/imgui")
+
+if(WIN32)
+    add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/assimp")
+    add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/glfw")
+    add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/glad")
+    add_subdirectory("${PROJECT_SOURCE_DIR}/Extern/imgui")
+endif(WIN32)
+
 set(BUILD_SHARED_LIBS OFF)
 
 add_subdirectory("${PROJECT_SOURCE_DIR}/Engine/")


### PR DESCRIPTION
Avoids building large dependencies by using libraries provided by OS, also fixes a cmake warning by explicitly choosing libGL over GLVND.