### PR TITLE
Add build workflow to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Builder
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build-windows:
+    name: Windows Build
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure
+        run: |
+          mkdir Build
+          cd Build
+          cmake -G "MinGW Makefiles" -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=RELEASE ..
+      - name: Build
+        run: |
+          cd Build
+          make -j4
+
+  build-linux:
+    name: Linux Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: libx11-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl1-mesa-dev libglu1-mesa-dev
+          version: 1.0
+      - name: Configure
+        run: |
+          mkdir Build
+          cd Build
+          cmake -G "Unix Makefiles" -DCMAKE_CXX_COMPILER=g++ -DCMAKE_BUILD_TYPE=RELEASE ..
+      - name: Build
+        run: |
+          cd Build
+          make -j4


### PR DESCRIPTION
Issue #106. Builds on Windows and Linux. Caches Linux dependencies. Runs on every push and PR.

Note that it takes some time to build it. Linux builds are a bit faster. My testing showed Linux builds took 7-9 minutes, while Windows took 12-15 minutes. Not sure if the parallelization `make -j4` really took effect on Windows, or if it's just slower in general.

An addition to this could be to upload tarballs of the binary + other necessary files (`Resources/`?).

I was originally planning on doing this last week, but got stuck on getting it to build on Linux then. I realize someone else was assigned to this issue, but if they still do it you could give them `hacktoberfest-accepted` label even if you don't merge it (though I don't see any fork that they could be working on).