### PR TITLE
Fix most warnings. Add UNUSED macro.

### DIFF
--- a/Editor/Core/EditorModules.cpp
+++ b/Editor/Core/EditorModules.cpp
@@ -264,7 +264,7 @@ namespace DT
     {
         ImGui::Begin("Console");
 
-        ImGui::Text(engine->debug.log.c_str());
+        ImGui::Text("%s", engine->debug.log.c_str());
 
         ImGui::End();
     }

--- a/Engine/Components/Component.h
+++ b/Engine/Components/Component.h
@@ -34,6 +34,7 @@ aryanbaburajan2007@gmail.com
 
 #include <Core/Window.h>
 #include <Core/Entity.h>
+#include <Core/Macro.h>
 
 #define REGISTER(component)\
     DT_EXPORT Component *Register ## component(Entity entity, Scene *scene, bool init, RegisterAction action)\
@@ -100,7 +101,7 @@ namespace DT
          * @brief Virtual function for handling Component in a scene view
          * @param selected boolean representing if current entity is selected
          */
-        virtual void SceneView(bool selected) {}
+        virtual void SceneView(bool selected) {UNUSED(selected);}
 
         /**
          * @brief Virtual function for Component destruction

--- a/Engine/Components/DirectionalLight.cpp
+++ b/Engine/Components/DirectionalLight.cpp
@@ -20,6 +20,7 @@ the following email address:
 aryanbaburajan2007@gmail.com
 */
 
+#include <Core/Macro.h>
 #include <Components/DirectionalLight.h>
 
 namespace DT
@@ -68,6 +69,7 @@ namespace DT
 
     void DirectionalLight::SceneView(bool selected)
     {
+        UNUSED(selected);
         Tick();
     }
 

--- a/Engine/Components/MeshRenderer.cpp
+++ b/Engine/Components/MeshRenderer.cpp
@@ -20,6 +20,7 @@ the following email address:
 aryanbaburajan2007@gmail.com
 */
 
+#include <Core/Macro.h>
 #include <Components/MeshRenderer.h>
 
 namespace DT
@@ -54,6 +55,7 @@ namespace DT
 
     void MeshRenderer::SceneView(bool selected)
     {
+        UNUSED(selected);
         Tick();
     }
 

--- a/Engine/Components/PointLight.cpp
+++ b/Engine/Components/PointLight.cpp
@@ -20,6 +20,7 @@ the following email address:
 aryanbaburajan2007@gmail.com
 */
 
+#include <Core/Macro.h>
 #include <Components/PointLight.h>
 
 namespace DT
@@ -67,6 +68,7 @@ namespace DT
 
     void PointLight::SceneView(bool selected)
     {
+        UNUSED(selected);
         Tick();
     }
 

--- a/Engine/Core/Macro.h
+++ b/Engine/Core/Macro.h
@@ -36,3 +36,8 @@ aryanbaburajan2007@gmail.com
             exit(1);                                                                                      \
         }                                                                                                 \
     } while (0)
+
+/* This macro expression gets optimized out during compilation, but will
+ * satisfy the compiler from complaining about unused variables
+ */
+#define UNUSED(expr) do { (void)(expr); } while (0)

--- a/Engine/Core/Window.cpp
+++ b/Engine/Core/Window.cpp
@@ -21,11 +21,14 @@ aryanbaburajan2007@gmail.com
 */
 
 #include <Core/Window.h>
+#include <Core/Macro.h>
 
 namespace DT
 {
     void APIENTRY Window::GlDebugOutput(GLenum source, GLenum type, unsigned int id, GLenum severity, GLsizei length, const char *message, const void *userParam)
     {
+        UNUSED(length);
+        UNUSED(userParam);
         if(id == 131169 || id == 131185 || id == 131218 || id == 131204) return; 
 
         std::cout << "---------------" << std::endl;

--- a/Engine/Input/Input.cpp
+++ b/Engine/Input/Input.cpp
@@ -20,6 +20,7 @@ the following email address:
 aryanbaburajan2007@gmail.com
 */
 
+#include <Core/Macro.h>
 #include <Input/Input.h>
 
 namespace DT
@@ -81,6 +82,8 @@ namespace DT
 
     void Input::KeyCallback(GLFWwindow *window, int key, int scancode, int action, int mods)
     {
+        UNUSED(scancode);
+        UNUSED(mods);
         Input *input = reinterpret_cast<UserPointer *>(glfwGetWindowUserPointer(window))->input;
 
         if (action == GLFW_PRESS)
@@ -91,6 +94,7 @@ namespace DT
 
     void Input::MouseButtonCallback(GLFWwindow* window, int button, int action, int mods)
     {
+        UNUSED(mods);
         Input *input = reinterpret_cast<UserPointer *>(glfwGetWindowUserPointer(window))->input;
 
         if (action == GLFW_PRESS)

--- a/Engine/Renderer/Cubemap.cpp
+++ b/Engine/Renderer/Cubemap.cpp
@@ -43,6 +43,8 @@ namespace DT
                     format = GL_RGB;
                 else if (nrChannels == 4)
                     format = GL_RGBA;
+                else
+                    format = GL_RGB;
 
                 glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, format, width, height, 0, format, GL_UNSIGNED_BYTE, data);
             }

--- a/Engine/Renderer/Texture.cpp
+++ b/Engine/Renderer/Texture.cpp
@@ -44,6 +44,8 @@ namespace DT
                 format = GL_RGB;
             else if (nrChannels == 4)
                 format = GL_RGBA;
+            else
+                format = GL_RGB;
 
             glBindTexture(GL_TEXTURE_2D, id);
             glTexImage2D(GL_TEXTURE_2D, 0, format, width, height, 0, format, GL_UNSIGNED_BYTE, data);


### PR DESCRIPTION
Issue #134. 

UNUSED macro can be used on unused variables to suppress the compiler warning. Most warnings were unused variables.

One warning fixed was ImGui::Text, which wants to use a format string.

Two warnings are still there and I do not know how to solve them. The variables require a fallback value if none of the if-statements are true, otherwise it is uninitialized. But I do not know what would be a good fallback value.
```
Ducktape/Engine/Renderer/Cubemap.cpp:39:24: warning: ‘format’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```
```
Ducktape/Engine/Renderer/Texture.cpp:49:25: warning: ‘format’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```